### PR TITLE
Corrected the extracted SPICE netlist of the level shifters

### DIFF
--- a/cells/lsbufhv2lv/sky130_fd_sc_hvl__lsbufhv2lv_1.spice
+++ b/cells/lsbufhv2lv/sky130_fd_sc_hvl__lsbufhv2lv_1.spice
@@ -16,20 +16,20 @@
 
 
 .subckt sky130_fd_sc_hvl__lsbufhv2lv_1 A LVPWR VGND VNB VPB VPWR X
-X0 a_30_207# a_30_1337# a_187_207# VNB sky130_fd_pr__nfet_g5v0d10v5 w=420000u l=500000u
-X1 a_30_443# a_30_1337# a_30_207# VPB sky130_fd_pr__pfet_g5v0d10v5 w=420000u l=500000u
-X2 X a_389_141# a_187_207# VNB sky130_fd_pr__nfet_01v8 w=740000u l=150000u
+X0 a_30_207# a_30_1337# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=420000u l=500000u
+X1 VPWR a_30_1337# a_30_207# VPB sky130_fd_pr__pfet_g5v0d10v5 w=420000u l=500000u
+X2 X a_389_141# VGND VNB sky130_fd_pr__nfet_01v8 w=740000u l=150000u
 X3 a_389_1337# a_30_1337# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
 X4 a_389_1337# a_30_1337# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
 X5 X a_389_141# LVPWR LVPWR sky130_fd_pr__pfet_01v8_hvt w=1.12e+06u l=150000u
 X6 a_389_141# a_389_1337# LVPWR LVPWR sky130_fd_pr__pfet_01v8_hvt w=1.12e+06u l=150000u
-X7 a_187_207# a_30_207# a_389_141# VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
-X8 a_389_141# a_30_207# a_187_207# VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
-X9 a_389_141# a_30_207# a_187_207# VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
+X7 VGND a_30_207# a_389_141# VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
+X8 a_389_141# a_30_207# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
+X9 a_389_141# a_30_207# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
 X10 VPWR A a_30_1337# VPB sky130_fd_pr__pfet_g5v0d10v5 w=420000u l=500000u
 X11 a_30_1337# A VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=420000u l=500000u
 X12 LVPWR a_389_141# a_389_1337# LVPWR sky130_fd_pr__pfet_01v8_hvt w=1.12e+06u l=150000u
-X13 a_389_141# a_30_207# a_187_207# VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
+X13 a_389_141# a_30_207# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
 X14 VGND a_30_1337# a_389_1337# VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
 X15 VGND a_30_1337# a_389_1337# VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
 .ends

--- a/cells/lsbuflv2hv/sky130_fd_sc_hvl__lsbuflv2hv_1.spice
+++ b/cells/lsbuflv2hv/sky130_fd_sc_hvl__lsbuflv2hv_1.spice
@@ -14,26 +14,26 @@
 *
 * SPDX-License-Identifier: Apache-2.0
 
-
 .subckt sky130_fd_sc_hvl__lsbuflv2hv_1 A LVPWR VGND VNB VPB VPWR X
 X0 VGND a_404_1133# a_504_1221# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X1 a_686_151# a_772_151# a_1197_107# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X2 a_1711_885# a_504_1221# VPWR VPB sky130_fd_pr__pfet_g5v0d10v5 w=1.5e+06u l=500000u
-X3 a_1711_885# a_504_1221# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
-X4 a_404_1133# A a_686_151# VNB sky130_fd_pr__nfet_01v8 w=840000u l=150000u
-X5 VPWR a_1711_885# X VPB sky130_fd_pr__pfet_g5v0d10v5 w=1.5e+06u l=500000u
-X6 a_404_1133# A LVPWR LVPWR sky130_fd_pr__pfet_01v8_hvt w=840000u l=150000u
-X7 VGND a_404_1133# a_504_1221# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X8 a_504_1221# a_404_1133# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X9 a_1197_107# a_504_1221# VPWR VPB sky130_fd_pr__pfet_g5v0d10v5 w=420000u l=1e+06u
-X10 a_686_151# a_772_151# a_1197_107# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X11 a_686_151# a_404_1133# a_772_151# VNB sky130_fd_pr__nfet_01v8 w=840000u l=150000u
-X12 LVPWR a_404_1133# a_772_151# LVPWR sky130_fd_pr__pfet_01v8_hvt w=840000u l=150000u
-X13 a_686_151# a_772_151# a_1197_107# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X14 VGND a_404_1133# a_504_1221# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X15 a_504_1221# a_1197_107# a_1606_563# VPB sky130_fd_pr__pfet_g5v0d10v5 w=420000u l=1e+06u
-X16 a_504_1221# a_404_1133# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X17 VGND a_1711_885# X VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
-X18 a_1197_107# a_772_151# a_686_151# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
-X19 a_1197_107# a_772_151# a_686_151# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X1 a_504_1221# a_404_1133# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X2 X a_1711_885# VPWR VPB sky130_fd_pr__pfet_g5v0d10v5 w=1.5e+06u l=500000u
+X3 X a_1711_885# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
+X4 VGND A a_404_1133# VNB sky130_fd_pr__nfet_01v8 w=840000u l=150000u
+X5 a_1197_107# a_772_151# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X6 VPWR a_1197_107# a_504_1221# VPB sky130_fd_pr__pfet_g5v0d10v5 w=420000u l=1e+06u
+X7 a_504_1221# a_404_1133# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X8 a_1197_107# a_772_151# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X9 a_772_151# a_404_1133# VGND VNB sky130_fd_pr__nfet_01v8 w=840000u l=150000u
+X10 a_504_1221# a_404_1133# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X11 VGND a_404_1133# a_504_1221# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X12 LVPWR A a_404_1133# LVPWR sky130_fd_pr__pfet_01v8_hvt w=840000u l=150000u
+X13 VGND a_772_151# a_1197_107# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X14 VPWR a_504_1221# a_1711_885# VPB sky130_fd_pr__pfet_g5v0d10v5 w=1.5e+06u l=500000u
+X15 VGND a_504_1221# a_1711_885# VNB sky130_fd_pr__nfet_g5v0d10v5 w=750000u l=500000u
+X16 VGND a_772_151# a_1197_107# VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X17 a_772_151# a_404_1133# LVPWR LVPWR sky130_fd_pr__pfet_01v8_hvt w=840000u l=150000u
+X18 a_1197_107# a_772_151# VGND VNB sky130_fd_pr__nfet_g5v0d10v5 w=1.5e+06u l=500000u
+X19 VPWR a_504_1221# a_1197_107# VPB sky130_fd_pr__pfet_g5v0d10v5 w=420000u l=1e+06u
 .ends
+


### PR DESCRIPTION
Corrected the extracted SPICE netlist of the HVL standard cell library level shifter buffers (correction missed in the first pass of updates).